### PR TITLE
Add publishing options

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,6 +18,8 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:3.1.4'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$versions.kotlin"
+        classpath "com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.4"
+        classpath "com.github.dcendents:android-maven-gradle-plugin:2.1"
     }
 }
 

--- a/sweetest/build.gradle
+++ b/sweetest/build.gradle
@@ -11,3 +11,5 @@ dependencies {
     api "io.cucumber:cucumber-picocontainer:$versions.cucumber"
     api "junit:junit:4.12"
 }
+
+apply from: 'publish.gradle'

--- a/sweetest/publish.gradle
+++ b/sweetest/publish.gradle
@@ -1,0 +1,62 @@
+apply plugin: 'com.github.dcendents.android-maven'
+apply plugin: 'com.jfrog.bintray'
+
+def libName = 'sweetest'
+def libGroup = 'com.mysugr.' + libName
+def libSite = 'https://github.com/mysugr/' + libName
+def libGit = libSite + '.git'
+def libTracker = libSite + '/issues'
+
+group libGroup
+version '1.0.0'
+
+Properties properties = new Properties()
+properties.load(rootProject.file('local.properties').newDataInputStream())
+
+bintray {
+    user properties.getProperty('bintray_user')
+    key properties.getProperty('bintray_key')
+    configurations = ['archives']
+    pkg {
+        repo = 'maven'
+        name = libName
+        websiteUrl = libSite
+        issueTrackerUrl = libTracker
+        vcsUrl = libGit
+        licenses = ['Apache-2.0']
+        publish = true
+        publicDownloadNumbers = true
+    }
+}
+
+install {
+    repositories.mavenInstaller {
+        pom.project {
+            packaging 'aar'
+            groupId libGroup
+            artifactId libName
+            name libName
+            url libSite
+            licenses {
+                license {
+                    name 'The Apache Software License, Version 2.0'
+                    url 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+                }
+            }
+            scm {
+                connection libGit
+                developerConnection libGit
+                url libSite
+            }
+        }
+    }
+}
+
+task sourcesJar(type: Jar) {
+    from sourceSets.main.java.srcDirs
+    classifier 'sources'
+}
+
+artifacts {
+    archives sourcesJar
+}

--- a/sweetest/publish.gradle
+++ b/sweetest/publish.gradle
@@ -20,6 +20,7 @@ bintray {
     pkg {
         repo = 'maven'
         name = libName
+        userOrg = 'mysugr'
         websiteUrl = libSite
         issueTrackerUrl = libTracker
         vcsUrl = libGit


### PR DESCRIPTION
This is missing. In the `local.properties` file:
```
bintray_user = whoever
bintray_key = key_for_whoever
```

After that, `./gradlew bintrayUpload`