### PR TITLE
Support for onTearDown

### DIFF
--- a/app/src/test/java/com/mysugr/android/testing/example/feature/AppCucumberHooks.kt
+++ b/app/src/test/java/com/mysugr/android/testing/example/feature/AppCucumberHooks.kt
@@ -4,6 +4,7 @@ import com.mysugr.sweetest.framework.context.TestContext
 import com.mysugr.sweetest.framework.cucumber.HookOrder
 import com.mysugr.sweetest.framework.environment.TestEnvironment
 import com.mysugr.sweetest.framework.flow.InitializationStep
+import cucumber.api.java.After
 import cucumber.api.java.Before
 
 class AppCucumberHooks(private val testContext: TestContext) {
@@ -26,5 +27,10 @@ class AppCucumberHooks(private val testContext: TestContext) {
     @Before(order = HookOrder.SETUP)
     fun setUp() {
         testContext.workflow.proceedTo(InitializationStep.SET_UP)
+    }
+
+    @After
+    fun tearDown() {
+        testContext.workflow.proceedTo(InitializationStep.TEAR_DOWN)
     }
 }

--- a/sweetest/src/main/java/com/mysugr/sweetest/framework/base/BaseJUnitTest.kt
+++ b/sweetest/src/main/java/com/mysugr/sweetest/framework/base/BaseJUnitTest.kt
@@ -2,6 +2,7 @@ package com.mysugr.sweetest.framework.base
 
 import com.mysugr.sweetest.framework.build.TestBuilder
 import com.mysugr.sweetest.framework.configuration.ModuleTestingConfiguration
+import org.junit.After
 import org.junit.Before
 
 abstract class BaseJUnitTest(private val moduleTestingConfiguration: ModuleTestingConfiguration) : TestingAccessor {
@@ -15,5 +16,10 @@ abstract class BaseJUnitTest(private val moduleTestingConfiguration: ModuleTesti
     @Before
     fun junitBefore() {
         accessor.testContext.workflow.run()
+    }
+
+    @After
+    fun junitAfter() {
+        accessor.testContext.workflow.finish()
     }
 }

--- a/sweetest/src/main/java/com/mysugr/sweetest/framework/build/BaseBuilder.kt
+++ b/sweetest/src/main/java/com/mysugr/sweetest/framework/build/BaseBuilder.kt
@@ -11,6 +11,7 @@ import com.mysugr.sweetest.framework.factory.FactoryRunner2
 import com.mysugr.sweetest.framework.factory.FactoryRunner3
 import com.mysugr.sweetest.framework.flow.InitializationStep.INITIALIZE_DEPENDENCIES
 import com.mysugr.sweetest.framework.flow.InitializationStep.SET_UP
+import com.mysugr.sweetest.framework.flow.InitializationStep.TEAR_DOWN
 import kotlin.reflect.KClass
 
 private const val dependencyModeDeprecationMessage = "Dependency modes like \"REAL\" or \"MOCK\" " +
@@ -164,5 +165,8 @@ abstract class BaseBuilder<TSelf, TResult : BaseAccessor>(
         testContext.workflow.subscribe(SET_UP, run)
     }
 
-    // TODO onTearDown
+    fun onTearDown(run: () -> Unit) = apply {
+        checkNotYetBuilt()
+        testContext.workflow.subscribe(TEAR_DOWN, run)
+    }
 }

--- a/sweetest/src/main/java/com/mysugr/sweetest/framework/context/WorkflowTestContext.kt
+++ b/sweetest/src/main/java/com/mysugr/sweetest/framework/context/WorkflowTestContext.kt
@@ -4,8 +4,7 @@ import com.mysugr.sweetest.framework.flow.InitializationStep
 
 class WorkflowTestContext internal constructor(private val steps: StepsTestContext) {
 
-    var currentStep: InitializationStep = InitializationStep.INITIALIZE_FRAMEWORK
-        private set
+    private var currentStep: InitializationStep = InitializationStep.INITIALIZE_FRAMEWORK
 
     private val supportedSubscriptionSteps = listOf(
         InitializationStep.INITIALIZE_STEPS,
@@ -47,18 +46,18 @@ class WorkflowTestContext internal constructor(private val steps: StepsTestConte
     }
 
     private fun runStep(step: InitializationStep) {
-        currentStep = step
-        if (currentStep == InitializationStep.INITIALIZE_DEPENDENCIES) {
+        if (step == InitializationStep.INITIALIZE_DEPENDENCIES) {
             onBeforeInitializeDependencies()
         }
-        triggerHandler(step)
+        triggerHandlerFor(step)
+        currentStep = step
     }
 
     private fun onBeforeInitializeDependencies() {
         steps.finalizeSetUp()
     }
 
-    private fun triggerHandler(step: InitializationStep) {
+    private fun triggerHandlerFor(step: InitializationStep) {
         val stepHandlers = subscriptionHandlers[step] ?: return
         // Can't use iterator as list is likely to be changed during iteration
         var i = 0

--- a/sweetest/src/main/java/com/mysugr/sweetest/framework/context/WorkflowTestContext.kt
+++ b/sweetest/src/main/java/com/mysugr/sweetest/framework/context/WorkflowTestContext.kt
@@ -42,7 +42,8 @@ class WorkflowTestContext internal constructor(private val steps: StepsTestConte
     }
 
     fun subscribe(step: InitializationStep, handler: () -> Unit) {
-        if (currentStep.isAfter(step)) {
+        check(step != INITIALIZE_FRAMEWORK && step != DONE) { "INITIALIZE_FRAMEWORK and DONE are not supported" }
+        if (currentStep.isAfterOrSame(step)) {
             throw IllegalStateException("You can't subscribe to a workflow step whose execution is already finished!")
         } else {
             stepHandlers[step]?.add(StepHandler(handler))

--- a/sweetest/src/main/java/com/mysugr/sweetest/framework/flow/InitializationStep.kt
+++ b/sweetest/src/main/java/com/mysugr/sweetest/framework/flow/InitializationStep.kt
@@ -5,7 +5,9 @@ enum class InitializationStep(val order: Int) {
     INITIALIZE_STEPS(1),
     INITIALIZE_DEPENDENCIES(2),
     SET_UP(3),
-    DONE(4);
+    RUNNING(4),
+    TEAR_DOWN(5),
+    DONE(6);
 
     fun isBeforeOrSame(other: InitializationStep) = other.order >= order
     fun isBefore(other: InitializationStep) = other.order > order

--- a/sweetest/src/test/java/com/mysugr/sweetest/WorkflowTest.kt
+++ b/sweetest/src/test/java/com/mysugr/sweetest/WorkflowTest.kt
@@ -1,0 +1,41 @@
+package com.mysugr.sweetest
+
+import com.mysugr.sweetest.framework.base.BaseJUnitTest
+import com.mysugr.sweetest.framework.configuration.moduleTestingConfiguration
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class WorkflowTest {
+
+    @Test
+    fun `Normal test workflow`() {
+
+        val trackedEvents = mutableListOf<String>()
+
+        val test = object : BaseJUnitTest(moduleTestingConfiguration()) {
+            override fun configure() = super.configure()
+                .onInitializeSteps { trackedEvents += "initializeSteps" }
+                .onInitializeDependencies { trackedEvents += "initializeDependencies" }
+                .onSetUp { trackedEvents += "setUp" }
+                .onTearDown { trackedEvents += "tearDown" }
+
+            fun testFunction() {
+                trackedEvents += "run test function"
+            }
+        }
+
+        test.junitBefore()
+        test.testFunction()
+        test.junitAfter()
+
+        assertEquals(
+            listOf(
+                "initializeSteps",
+                "initializeDependencies",
+                "setUp",
+                "run test function",
+                "tearDown"
+            ), trackedEvents
+        )
+    }
+}

--- a/sweetest/src/test/java/com/mysugr/sweetest/framework/context/WorkflowTestContextTest.kt
+++ b/sweetest/src/test/java/com/mysugr/sweetest/framework/context/WorkflowTestContextTest.kt
@@ -1,0 +1,94 @@
+package com.mysugr.sweetest.framework.context
+
+import com.mysugr.sweetest.framework.flow.InitializationStep
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.mockito.Mockito
+import org.mockito.Mockito.`when`
+
+class WorkflowTestContextTest {
+
+    val stepsContext = Mockito.mock(StepsTestContext::class.java)
+    val sut = WorkflowTestContext(stepsContext)
+
+    val trackedEvents = mutableListOf<String>()
+
+    @Test
+    fun `Runs through all steps`() {
+
+        trackEvents()
+
+        sut.run()
+
+        val expectedEvents = listOf(
+            "INITIALIZE_STEPS",
+            "finalize steps setup",
+            "INITIALIZE_DEPENDENCIES",
+            "SET_UP"
+        )
+
+        assertEquals(expectedEvents, trackedEvents)
+    }
+
+    @Test
+    fun `Runs through part of steps`() {
+
+        trackEvents()
+
+        sut.proceedTo(InitializationStep.INITIALIZE_STEPS)
+
+        assertEquals(
+            listOf(
+                "INITIALIZE_STEPS"
+            ), trackedEvents
+        )
+
+        sut.proceedTo(InitializationStep.INITIALIZE_DEPENDENCIES)
+
+        assertEquals(
+            listOf(
+                "INITIALIZE_STEPS",
+                "finalize steps setup",
+                "INITIALIZE_DEPENDENCIES"
+                ), trackedEvents
+        )
+    }
+
+    @Test(expected = Exception::class)
+    fun `Can't subscribe to INITIALIZE_FRAMEWORK`() {
+        sut.subscribe(InitializationStep.INITIALIZE_FRAMEWORK) { }
+    }
+
+    @Test(expected = Exception::class)
+    fun `Can't subscribe to DONE`() {
+        sut.subscribe(InitializationStep.DONE) { }
+    }
+
+    @Test(expected = Exception::class)
+    fun `Can't subscribe step already executed`() {
+        sut.proceedTo(InitializationStep.INITIALIZE_STEPS)
+        sut.subscribe(InitializationStep.INITIALIZE_STEPS) { }
+    }
+
+    @Test(expected = Exception::class)
+    fun `Can't proceed to to DONE`() {
+        sut.proceedTo(InitializationStep.DONE)
+    }
+
+    @Test(expected = Exception::class)
+    fun `Can't proceed to step already executed`() {
+        sut.proceedTo(InitializationStep.INITIALIZE_DEPENDENCIES)
+        sut.proceedTo(InitializationStep.INITIALIZE_DEPENDENCIES)
+    }
+
+    private fun trackEvents() {
+        sut.subscribe(InitializationStep.INITIALIZE_STEPS) { trackedEvents += "INITIALIZE_STEPS" }
+        sut.subscribe(InitializationStep.INITIALIZE_DEPENDENCIES) { trackedEvents += "INITIALIZE_DEPENDENCIES" }
+        sut.subscribe(InitializationStep.SET_UP) { trackedEvents += "SET_UP" }
+
+        `when`(stepsContext.finalizeSetUp()).then {
+            trackedEvents += "finalize steps setup"
+            Unit
+        }
+    }
+}

--- a/sweetest/src/test/java/com/mysugr/sweetest/framework/context/WorkflowTestContextTest.kt
+++ b/sweetest/src/test/java/com/mysugr/sweetest/framework/context/WorkflowTestContextTest.kt
@@ -2,6 +2,7 @@ package com.mysugr.sweetest.framework.context
 
 import com.mysugr.sweetest.framework.flow.InitializationStep
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.mockito.Mockito
 import org.mockito.Mockito.`when`
@@ -117,6 +118,19 @@ class WorkflowTestContextTest {
     fun `Can't proceed to step already executed`() {
         sut.proceedTo(InitializationStep.INITIALIZE_DEPENDENCIES)
         sut.proceedTo(InitializationStep.INITIALIZE_DEPENDENCIES)
+    }
+
+    @Test
+    fun `Can add handler during execution of same event`() {
+        var executed = false
+        sut.subscribe(InitializationStep.INITIALIZE_STEPS) {
+            sut.subscribe(InitializationStep.INITIALIZE_STEPS) {
+                executed = true
+            }
+        }
+        sut.proceedTo(InitializationStep.INITIALIZE_STEPS)
+
+        assertTrue(executed)
     }
 
     private fun trackEvents() {

--- a/sweetest/src/test/java/com/mysugr/sweetest/framework/context/WorkflowTestContextTest.kt
+++ b/sweetest/src/test/java/com/mysugr/sweetest/framework/context/WorkflowTestContextTest.kt
@@ -20,14 +20,28 @@ class WorkflowTestContextTest {
 
         sut.run()
 
-        val expectedEvents = listOf(
-            "INITIALIZE_STEPS",
-            "finalize steps setup",
-            "INITIALIZE_DEPENDENCIES",
-            "SET_UP"
+        assertEquals(
+            listOf(
+                "INITIALIZE_STEPS",
+                "finalize steps setup",
+                "INITIALIZE_DEPENDENCIES",
+                "SET_UP",
+                "RUNNING"
+            ), trackedEvents
         )
 
-        assertEquals(expectedEvents, trackedEvents)
+        sut.finish()
+
+        assertEquals(
+            listOf(
+                "INITIALIZE_STEPS",
+                "finalize steps setup",
+                "INITIALIZE_DEPENDENCIES",
+                "SET_UP",
+                "RUNNING",
+                "TEAR_DOWN"
+            ), trackedEvents
+        )
     }
 
     @Test
@@ -50,7 +64,31 @@ class WorkflowTestContextTest {
                 "INITIALIZE_STEPS",
                 "finalize steps setup",
                 "INITIALIZE_DEPENDENCIES"
-                ), trackedEvents
+            ), trackedEvents
+        )
+    }
+
+    @Test
+    fun `Doesn't skip steps`() {
+        trackEvents()
+
+        sut.proceedTo(InitializationStep.INITIALIZE_STEPS)
+
+        assertEquals(
+            listOf(
+                "INITIALIZE_STEPS"
+            ), trackedEvents
+        )
+
+        sut.proceedTo(InitializationStep.SET_UP)
+
+        assertEquals(
+            listOf(
+                "INITIALIZE_STEPS",
+                "finalize steps setup",
+                "INITIALIZE_DEPENDENCIES",
+                "SET_UP"
+            ), trackedEvents
         )
     }
 
@@ -85,6 +123,8 @@ class WorkflowTestContextTest {
         sut.subscribe(InitializationStep.INITIALIZE_STEPS) { trackedEvents += "INITIALIZE_STEPS" }
         sut.subscribe(InitializationStep.INITIALIZE_DEPENDENCIES) { trackedEvents += "INITIALIZE_DEPENDENCIES" }
         sut.subscribe(InitializationStep.SET_UP) { trackedEvents += "SET_UP" }
+        sut.subscribe(InitializationStep.RUNNING) { trackedEvents += "RUNNING" }
+        sut.subscribe(InitializationStep.TEAR_DOWN) { trackedEvents += "TEAR_DOWN" }
 
         `when`(stepsContext.finalizeSetUp()).then {
             trackedEvents += "finalize steps setup"


### PR DESCRIPTION
* Fixed major inconvenience, can now just use `.onTearDown { ... }`
* Prerequisite for upcoming `TestCoroutineScope` support